### PR TITLE
add linkpull label to pr's merge step

### DIFF
--- a/config.go
+++ b/config.go
@@ -85,6 +85,10 @@ type botConfig struct {
 	// that must be available to merge pr
 	LabelsForMerge []string `json:"labels_for_merge,omitempty"`
 
+	// LabelsNotAllowMerge means that if pull request has these labels, it can not been merged
+	// even all conditions are met
+	LabelsNotAllowMerge []string `json:"labels_not_allow_merge,omitempty"`
+
 	// MissingLabelsForMerge specifies the ones which a PR must not have to be merged.
 	MissingLabelsForMerge []string `json:"missing_labels_for_merge,omitempty"`
 

--- a/merge.go
+++ b/merge.go
@@ -148,6 +148,14 @@ func (m *mergeHelper) canMerge(log *logrus.Entry) ([]string, bool) {
 		return []string{}, false
 	}
 
+	for label := range m.getPRLabels() {
+		for _, l := range m.cfg.LabelsNotAllowMerge {
+			if l == label {
+				return []string{}, false
+			}
+		}
+	}
+
 	if r := isLabelMatched(m.getPRLabels(), m.cfg, ops, log); len(r) > 0 {
 		return r, false
 	}


### PR DESCRIPTION
test pr link: https://gitee.com/new-op2/community/pulls/3

pr can't be merged even all the labels are ready, because of 'linkpull' exists.After removing 'linkpull' label, pr has been merged by bot as usual.