### PR TITLE
The approver add the branch_keeper

### DIFF
--- a/branch_keeper.go
+++ b/branch_keeper.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/yaml"
+
+	"github.com/sirupsen/logrus"
+
+	sdk "github.com/opensourceways/go-gitee/gitee"
+)
+
+// CheckBranchKeeper will return format and eg: true, true, error
+// false, false, err: There will hava error happen, and it will return error
+// true, true, nil: The approved commenter in branch keeper list
+// false, true, nil: The approved commenter not in branch keeper list
+// false, false, nil: The sig-info.yaml is not setting branch keeper
+func (bot *robot) CheckBranchKeeper(
+	org, repo, commenter string,
+	pr *sdk.PullRequestHook,
+	cfg *botConfig,
+	log *logrus.Entry,
+) (bool, bool, error) {
+	sigInfoFiles, err := bot.getFiles(
+		cfg.BranchKeeper.Owner,
+		cfg.BranchKeeper.Repo,
+		cfg.BranchKeeper.Branch,
+		sigInfoFile,
+		log,
+	)
+
+	if err != nil {
+		return false, false, err
+	}
+
+	keepBranches := make(map[string]sets.String)
+	fullPath := fmt.Sprintf(`%s/%s/%s`, org, repo, pr.GetBase().GetRef())
+
+	for _, file := range sigInfoFiles.Files {
+		if strings.HasPrefix(file.Path.FullPath(), "archived_sigs/") {
+			continue
+		}
+
+		decodeKeepBranchFile(file.Content, keepBranches, log)
+	}
+
+	if value, exist := keepBranches[fullPath]; exist {
+		if value.Has(commenter) {
+			return true, true, nil
+		}
+
+		return false, true, nil
+	}
+
+	return false, false, nil
+}
+
+func decodeKeepBranchFile(content string, keepBranches map[string]sets.String, log *logrus.Entry) {
+	c, err := base64.StdEncoding.DecodeString(content)
+
+	if err != nil {
+		log.WithError(err).Error("decode file")
+
+		return
+	}
+
+	var m SigInfos
+
+	if err = yaml.Unmarshal(c, &m); err != nil {
+		log.WithError(err).Error("code yaml file")
+
+		return
+	}
+
+	maintainers := sets.NewString()
+
+	for _, maintainer := range m.Maintainers {
+		maintainers.Insert(maintainer.GiteeID)
+	}
+
+	for _, branchKeeper := range m.Branches {
+		keepers := sets.NewString()
+
+		for _, keeper := range branchKeeper.Keeper {
+			keepers.Insert(keeper.GiteeID)
+		}
+
+		keepers = keepers.Union(maintainers)
+
+		for _, branch := range branchKeeper.RepoBranch {
+			fullPath := fmt.Sprintf(`%s/%s`, branch.Repo, branch.Branch)
+
+			keepBranches[fullPath] = keepers
+		}
+	}
+
+	return
+}

--- a/config.go
+++ b/config.go
@@ -104,6 +104,9 @@ type botConfig struct {
 
 	// FreezeFile is the freeze branch of community
 	FreezeFile []freezeFile `json:"freeze_file,omitempty"`
+
+	// BranchKeeper is used to maintain the approve label or cancel approve maintainer list
+	BranchKeeper branchKeeper `json:"branch_keeper,omitempty"`
 }
 
 func (c *botConfig) setDefault() {
@@ -141,6 +144,11 @@ func (c *botConfig) validate() error {
 		return v.validate()
 	}
 
+	// todo must test branchKeeper is nil
+	if err := c.BranchKeeper.validate(); err != nil {
+		return err
+	}
+
 	return c.RepoFilter.Validate()
 }
 
@@ -170,6 +178,28 @@ func (f freezeFile) validate() error {
 
 	if f.Path == "" {
 		return fmt.Errorf("missing path of freeze file")
+	}
+
+	return nil
+}
+
+type branchKeeper struct {
+	Owner  string `json:"owner" required:"true"`
+	Repo   string `json:"repo" required:"true"`
+	Branch string `json:"branch" required:"true"`
+}
+
+func (b branchKeeper) validate() error {
+	if b.Owner == "" {
+		return fmt.Errorf("missing owner of branch keeper")
+	}
+
+	if b.Repo == "" {
+		return fmt.Errorf("missing repo of branch keeper")
+	}
+
+	if b.Branch == "" {
+		return fmt.Errorf("missing branch of branch keeper")
 	}
 
 	return nil

--- a/sig_info.go
+++ b/sig_info.go
@@ -10,6 +10,7 @@ type SigInfos struct {
 	Mentors      []Mentor     `json:"mentors,omitempty"`
 	Maintainers  []Maintainer `json:"maintainers,omitempty"`
 	Repositories []RepoAdmin  `json:"repositories,omitempty"`
+	Branches     []Branches   `json:"branches,omitempty"`
 }
 
 // Maintainer struct.
@@ -74,4 +75,23 @@ type Branch struct {
 	Name       string `json:"name,omitempty"`
 	CreateFrom string `json:"create_from,omitempty"`
 	Type       string `json:"type,omitempty"`
+}
+
+// Branches struct.
+type Branches struct {
+	RepoBranch []RepoBranch `json:"repo_branch,omitempty"`
+	Keeper     []Keeper     `json:"keeper,omitempty"`
+}
+
+// RepoBranch struct
+type RepoBranch struct {
+	Repo   string `json:"repo"`
+	Branch string `json:"branch"`
+}
+
+// Keeper struct.
+type Keeper struct {
+	GiteeID string `json:"gitee_id,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Email   string `json:"email,omitempty"`
 }


### PR DESCRIPTION
<1>.覆盖的测试用例：
测试场景：
1.community仓库sigs/kernel/sig-info.yaml中设置branches参数，打approve/approve cancel的人在名单中，此时成功打上approve标签或者取消标签。                                          测试ok
2.community仓库sigs/kernel/sig-info.yaml中设置branches参数，打approve/approve cancel的人不在名单中，此时报无权限，注意在maintainers或者committers也无效。                        测试ok，  maintainers默认加上
3.community仓库sigs/kernel/sig-info.yaml中没有设置branches参数，打approve/approve cancel的人在maintainers或者committers中（仓库成员管理），此时成功打上approve标签或者取消标签。 测试ok
4.community仓库sigs/kernel/sig-info.yaml中没有设置branches参数，打approve/approve cancel的人不在maintainers或者committers中，此时报无权限。                                      测试ok                           
5.验证修改sigs/kernel/sig-info.yaml文件后，owner-file-cache是否会受影响？ 不会，owner-file-cache获取的是owners的文件，而其余项目，例如welcom等都是用SigInfos结构体去接，如果缺少字段，则不存在而不会报错。 测试ok
	type SigInfos struct {
		Name         string       `json:"name,omitempty"`
		Description  string       `json:"description,omitempty"`
		MailingList  string       `json:"mailing_list,omitempty"`
		MeetingURL   string       `json:"meeting_url,omitempty"`
		MatureLevel  string       `json:"mature_level,omitempty"`
		Mentors      []Mentor     `json:"mentors,omitempty"`
		Maintainers  []Maintainer `json:"maintainers,omitempty"`
		Repositories []RepoAdmin  `json:"repositories,omitempty"`
	}

6.welcome中@的人员是否需要更改为branch-keeper?    不需要，没有@maintainer，如果有，则怎么办？   经和志哥讨论，因为branch_keeper看护者都是maintainer或者是committers,本身就会@他们,所以不需要处理。

7.梳理一下合入的规则，看是否有影响？ 
    有影响，sig合入PR的时候，会根据打标签者(lgtm, approve, ack）去生成对应的Reviewed-by，Signed-off-by，Acked-by等内容， 在这里lgtm的所有者发生变化后，它会去maintainer和committer里面寻找对应的name和email, 因为branch_keeper看护者都是maintainer或者是committers,本身就会@他们,所以不需要处理。
	
	流程分析：
	1.遍历所有的评论,如果是内核仓库：
		1.获取lgtm, approve, ack的评论者
		2.获取kernel的sig-info.yaml文件，遍历maintainers, commmitters, contributors等内容
		3.遍历lgtm评论者，判断是否在committers和maintainers，contributors? 在则采集
		  遍历approve评论者，判断是否在committers和maintainers?在则采集
		  遍历ack评论者，判断是否在committers和maintainers?在则采集
		4.将采集者组装成返回的数据。
	2.遍历所有的评论，如果不是内核仓库：
		1.获取lgtm, approve, ack的评论者
		2.将lgtm, approve, ack的评论者组装成commit信息。
		
8.门禁增加sig-info.yaml增加校验。

<2> 需要在https://github.com/opensourceways/infra-mindspore/blob/master/applications/robot-gitee-openeuler/openeuler-review/kustomization.yaml增加keeper_branch字段，参考模板：
![image](https://github.com/opensourceways/robot-gitee-openeuler-review/assets/50572318/1bab7805-fad6-4958-b518-4589e7674df4)


